### PR TITLE
Revert "Updated the version of Arduino IDE used to v1.8.2"

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -20,9 +20,9 @@ sleep 3
 export DISPLAY=:1.0
 
 # download and install arduino 1.6.5
-wget https://downloads.arduino.cc/arduino-1.8.2-linux64.tar.xz
-tar xf arduino-1.8.2-linux64.tar.xz
-mv arduino-1.8.2 $HOME/arduino_ide
+wget https://downloads.arduino.cc/arduino-1.6.12-linux64.tar.xz
+tar xf arduino-1.6.12-linux64.tar.xz
+mv arduino-1.6.12 $HOME/arduino_ide
 
 # move this library to the arduino libraries folder
 ln -s $PWD $HOME/arduino_ide/libraries/Marzogh_Test_Library


### PR DESCRIPTION
Reverts Marzogh/Travis-CI#5. Arduino 1.8.2 running on the Travis setup appears to throw compilation errors that the same IDE running on DEbain on my laptop does not.