### PR TITLE
Correct mega fqbn

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@ export MAIN_PLATFORMS='declare -A main_platforms=( [uno]="arduino:avr:uno" [due]
 
 # associative array for other platforms that can be called explicitly in .travis.yml configs
 # this will be eval'd in the functions below because arrays can't be exported
-export AUX_PLATFORMS='declare -A aux_platforms=( [trinket]="adafruit:avr:trinket5" [gemma]="arduino:avr:gemma" [mega]="arduino:avr:mega" )'
+export AUX_PLATFORMS='declare -A aux_platforms=( [trinket]="adafruit:avr:trinket5" [gemma]="arduino:avr:gemma" [mega]="arduino:avr:mega:cpu=atmega2560" )'
 
 export CPLAY_PLATFORMS='declare -A cplay_platforms=( [cplayClassic]="arduino:avr:circuitplay32u4cat" [cplayExpress]="arduino:samd:adafruit_circuitplayground_m0" )'
 


### PR DESCRIPTION
Incomplete fqbn caused builds for mega to fail:
```
avr-g++: error: missing device or architecture after '-mmcu='
```
Demonstration:
https://travis-ci.org/boseji/xxtea-iot-crypt/builds/404114155#L513